### PR TITLE
ADR-002: Persistencia SQLite + Journaling (WAL)

### DIFF
--- a/tortilleria/README.md
+++ b/tortilleria/README.md
@@ -2,3 +2,5 @@
 
 ## ADRs
 - [ADR-0001: Stack Desktop Offline](docs/adr/0001-stack-desktop-nativephp.md)
+
+- [ADR-002: Persistencia SQLite + Journaling](docs/adr/0002-persistencia-sqlite-journaling.md)

--- a/tortilleria/docs/adr/0002-persistencia-sqlite-journaling.md
+++ b/tortilleria/docs/adr/0002-persistencia-sqlite-journaling.md
@@ -1,0 +1,84 @@
+# ADR-002 — Persistencia SQLite + Journaling (WAL)
+**Estado:** Propuesto  
+**Fecha:** 2025-08-24  
+**Decisores:** Equipo Tortillería (PO, Tech Lead)
+
+## Contexto
+Operación 100% offline en Windows (≥4 GB RAM), tolerando cortes de energía y cierres inesperados, con lectura concurrente fluida (POS/reportes), integridad de inventario/kardex/ventas y backups/restore simples.
+
+## Decisión
+Usar **SQLite** local con **Write-Ahead Logging (WAL)**, política de checkpoints, anti-corrupción y respaldo.
+
+### Ruta de la base de datos (Windows)
+- **Elegida:** C:\\ProgramData\\Tortilleria\\data\\app.sqlite  
+- **Alternativa:** %LocalAppData%\\Tortilleria\\data\\app.sqlite
+
+### PRAGMAs oficiales (producción; modo rendimiento entre paréntesis)
+- `PRAGMA journal_mode = WAL;`
+- `PRAGMA synchronous = NORMAL;` *(**FULL** en operaciones críticas: “corte de caja”, migraciones y actualización offline).*
+- `PRAGMA foreign_keys = ON;`
+- `PRAGMA busy_timeout = 5000;`
+- `PRAGMA wal_autocheckpoint = 1000;` *(ajustable por métricas)*
+- `PRAGMA locking_mode = NORMAL;`
+- `PRAGMA temp_store = MEMORY;`
+- **Al crear DB**: `PRAGMA page_size = 4096;`
+- Mantenimiento: `PRAGMA auto_vacuum = INCREMENTAL;` + `PRAGMA incremental_vacuum;`
+- Seguridad: `PRAGMA trusted_schema = OFF;`
+- Versionado: `PRAGMA user_version = <entero>`
+
+## Alternativas consideradas
+1) PostgreSQL local — robusto, pero instalación/servicio pesados para offline.  
+2) SQL Server Express LocalDB — footprint mayor y complejidad.  
+3) Archivos JSON/CSV — sin transacciones reales, riesgo de corrupción.  
+4) SQLite sin WAL — menor concurrencia y mayor latencia de escritura.
+
+## Consecuencias
+**Pro:** setup mínimo, ACID, buena lectura concurrente con WAL, backups sencillos.  
+**Contra:** gestionar tamaño del WAL y política de checkpoints; ajustar `synchronous` por caso.
+
+## RNF soportados
+Rendimiento (≥100 ventas/hora), confiabilidad tras crash, integridad (transacciones + FK), operación offline, seguridad (cifrado de backups), mantenibilidad (PRAGMAs documentados y métricas).
+
+## Estrategia WAL y checkpoints
+- Automático: `wal_autocheckpoint = 1000` páginas (ajustable).  
+- Manual (forzado):
+  - Al **salir** de la app.
+  - Tras **corte de caja** (con `synchronous=FULL`).
+  - Cuando **WAL > 256 MB** → `PRAGMA wal_checkpoint(TRUNCATE);` (fallback a `PASSIVE` si falla).
+
+## Plan anti-corrupción (cierres inesperados)
+- Transacciones en operaciones críticas.
+- `synchronous=NORMAL` por defecto; **FULL** en eventos críticos.
+- **Startup checks**: `PRAGMA quick_check` semanal o bajo demanda.
+- **Runbook**: backup con **Backup API** → restore → verificación → reintentos; registrar incidente.
+
+## Backups & restore
+- Frecuencia: diario (reten 7), semanal (reten 4) + **USB** opcional.
+- Método: **SQLite Backup API** (consistente con WAL).
+- Verificación: `PRAGMA integrity_check` sobre el **backup**.
+- Cifrado: ZIP/AES o EFS; custodiar llaves.
+- Restore guiado: selector → verificación → reemplazo atómico → reabrir app.
+
+## Observabilidad
+- Log inicial: valores reales de PRAGMAs y rutas.
+- Métricas: tamaño DB, tamaño WAL, tiempo de checkpoint, #`SQLITE_BUSY`, #recoveries.
+- Alertas locales: WAL > 256 MB, `quick_check` fallido, ≥3 `BUSY`/60s.
+
+## Métricas de aceptación
+- Resiliencia a crash: tras abortar 100 escrituras, la DB abre y pasa `quick_check`.
+- WAL controlado: no supera 256 MB bajo carga típica o se checkpoint-ea a tiempo.
+- Corte de caja seguro: con **FULL**, latencia aceptable e integridad ok.
+- Backup/restore: backup diario verificado y restore exitoso en ≤5 min.
+
+## Plan de adopción
+1) Congelar PRAGMAs y rutas.  
+2) Automatizar checkpoints (salida/corte/umbral WAL).  
+3) Programar `quick_check` semanal y pipeline de backups.  
+4) Añadir logs/alertas.  
+5) Ensayar recuperación (tabletop + prueba en QA).
+
+## Aprobaciones
+- Tech Lead: ______ (fecha)  
+- QA Lead: ________ (fecha)  
+- Cliente/PO: _____ (fecha)
+

--- a/tortilleria/docs/db/pragmas-matriz-entornos.md
+++ b/tortilleria/docs/db/pragmas-matriz-entornos.md
@@ -1,0 +1,11 @@
+| PRAGMA / Parámetro      | dev                 | QA                  | prod                                   | Nota |
+|-------------------------|---------------------|---------------------|----------------------------------------|------|
+| journal_mode            | WAL                 | WAL                 | WAL                                    | —    |
+| synchronous             | NORMAL              | NORMAL              | NORMAL (**FULL** en eventos críticos)  | —    |
+| wal_autocheckpoint      | 500                 | 1000                | 1000                                   | Ajustar por métricas |
+| busy_timeout (ms)       | 3000                | 5000                | 5000                                   | —    |
+| page_size (al crear)    | 4096                | 4096                | 4096                                   | NTFS típico |
+| auto_vacuum             | INCREMENTAL         | INCREMENTAL         | INCREMENTAL                            | Ejecutar incremental_vacuum en valle |
+| foreign_keys            | ON                  | ON                  | ON                                     | —    |
+| trusted_schema          | OFF                 | OFF                 | OFF                                    | Si no se usan extensiones |
+| Umbral WAL (MB)         | 128                 | 256                 | 256                                    | TRUNCATE si supera |

--- a/tortilleria/docs/evidence/adr-002/checkpoint-template.txt
+++ b/tortilleria/docs/evidence/adr-002/checkpoint-template.txt
@@ -1,0 +1,1 @@
+sqlite3 "C:\\ProgramData\\Tortilleria\\data\\app.sqlite" "PRAGMA wal_checkpoint(TRUNCATE);"

--- a/tortilleria/docs/evidence/adr-002/quick_check-template.txt
+++ b/tortilleria/docs/evidence/adr-002/quick_check-template.txt
@@ -1,0 +1,2 @@
+sqlite3 "C:\\ProgramData\\Tortilleria\\data\\app.sqlite" "PRAGMA quick_check;"
+# Pega aquí la salida real cuando se ejecute en QA.

--- a/tortilleria/docs/ops/observabilidad-sqlite.md
+++ b/tortilleria/docs/ops/observabilidad-sqlite.md
@@ -1,0 +1,30 @@
+# Observabilidad SQLite
+
+## Logs iniciales
+- Ruta real de la base de datos y del WAL.
+- Valores efectivos de los PRAGMAs claves.
+
+## Métricas
+- Tamaño de la base y del WAL.
+- Duración de cada checkpoint.
+- Conteo de `SQLITE_BUSY`.
+- Número de recuperaciones ejecutadas.
+
+## Umbrales y alertas
+- WAL > 256 MB → alerta "Requiere checkpoint".
+- `quick_check` fallido → alerta crítica "Integridad comprometida".
+- ≥3 `BUSY` en 60s → aviso "Alta contención".
+
+## Formato de log (ejemplo)
+```json
+{
+  "ts": "2025-08-24T12:00:00Z",
+  "event": "startup",
+  "db_path": "C:/ProgramData/Tortilleria/data/app.sqlite",
+  "pragmas": {
+    "journal_mode": "wal",
+    "synchronous": "normal",
+    "wal_autocheckpoint": 1000
+  }
+}
+```

--- a/tortilleria/docs/ops/runbook-sqlite-recovery.md
+++ b/tortilleria/docs/ops/runbook-sqlite-recovery.md
@@ -1,0 +1,10 @@
+# Runbook — Recuperación SQLite
+
+1. **Detectar** el incidente (logs, error en apertura, alerta de integridad).
+2. **Poner la app en modo lectura-sola**; bloquear nuevas escrituras.
+3. Si el WAL supera el umbral o hay inconsistencia, ejecutar `PRAGMA wal_checkpoint(TRUNCATE);`.
+4. **Generar backup** con la **SQLite Backup API** hacia un archivo temporal seguro.
+5. Ejecutar `PRAGMA integrity_check` sobre el **backup** para validar consistencia.
+6. **Restore atómico**: reemplazar la base dañada por el backup verificado.
+7. **Verificar**: abrir la app y correr `PRAGMA quick_check`.
+8. **Registrar el incidente**: bitácora con causa raíz, acciones y resultado.


### PR DESCRIPTION
## Summary
- add ADR-002 for SQLite persistence using WAL
- document PRAGMA matrix, recovery runbook, and observability
- add evidence templates for quick_check and checkpoint

## Testing
- `npm test`

## Links
- [ADR-002](tortilleria/docs/adr/0002-persistencia-sqlite-journaling.md)
- [PRAGMAs matrix](tortilleria/docs/db/pragmas-matriz-entornos.md)
- [Runbook](tortilleria/docs/ops/runbook-sqlite-recovery.md)
- [Observabilidad](tortilleria/docs/ops/observabilidad-sqlite.md)

## Checklist
- [ ] Aprobación del cliente


------
https://chatgpt.com/codex/tasks/task_e_68ab4a86ea088325a89bb477682a07ab