### PR TITLE
Document SQLite ADR and architecture diagrams

### DIFF
--- a/tortilleria/README.md
+++ b/tortilleria/README.md
@@ -1,14 +1,21 @@
 # Tortilleria
 
 ## ADRs
-- [ADR-0001: Stack Desktop Offline](docs/adr/0001-stack-desktop-nativephp.md)
-
-- [ADR-002: Persistencia SQLite + Journaling](docs/adr/0002-persistencia-sqlite-journaling.md)
+- [ADR-0001: Stack Desktop Offline](tortilleria/docs/adr/0001-stack-desktop-nativephp.md)
+- [ADR-002: Persistencia SQLite + Journaling](tortilleria/docs/adr/0002-persistencia-sqlite-journaling.md)
 
 ## Diagramas C4
-- [Contexto](docs/arch/c4-contexto.md)
-- [Contenedores](docs/arch/c4-contenedores.md)
-- [Componentes · Backend](docs/diagramas/c4-componentes-backend.md)
-- [Componentes · Desktop](docs/diagramas/c4-componentes-desktop.md)
-- [Decisiones Caché/Colas](docs/diagramas/decisiones-cache-colas.md)
+- [Contexto](tortilleria/docs/arch/c4-contexto.md)
+- [Contenedores](tortilleria/docs/arch/c4-contenedores.md)
+- [Componentes · Backend](tortilleria/docs/diagramas/c4-componentes-backend.md)
+- [Componentes · Desktop](tortilleria/docs/diagramas/c4-componentes-desktop.md)
+- [Decisiones Caché/Colas](tortilleria/docs/diagramas/decisiones-cache-colas.md)
 
+## Seguridad (diseño)
+- [Matriz RBAC](tortilleria/docs/seguridad/rbac-matriz.md)
+- [Validación/Sanitización](tortilleria/docs/seguridad/validacion-sanitizacion.md)
+- [Auditoría](tortilleria/docs/seguridad/auditoria.md)
+
+## Backlog & Roadmap
+- [Backlog MoSCoW](tortilleria/docs/backlog/moscow.md)
+- [Roadmap SaaS](tortilleria/docs/roadmap/saas.md)

--- a/tortilleria/docs/adr/0002-persistencia-sqlite-journaling.md
+++ b/tortilleria/docs/adr/0002-persistencia-sqlite-journaling.md
@@ -1,24 +1,20 @@
 # ADR-002 — Persistencia SQLite + Journaling (WAL)
 **Estado:** Propuesto  
-**Fecha:** 2025-08-24  
+**Fecha:** 24/08/2025  
 **Decisores:** Equipo Tortillería (PO, Tech Lead)
 
 ## Contexto
-Operación 100% offline en Windows (≥4 GB RAM), tolerando cortes de energía y cierres inesperados, con lectura concurrente fluida (POS/reportes), integridad de inventario/kardex/ventas y backups/restore simples.
+Operación 100% offline en Windows (≥4 GB RAM) tolerando cortes de energía/cierres inesperados; lectura concurrente fluida (POS/reportes), integridad de inventario/kardex/ventas y backups/restore simples.
 
 ## Decisión
-Usar **SQLite** local con **Write-Ahead Logging (WAL)**, política de checkpoints, anti-corrupción y respaldo.
+Usar **SQLite** local con **Write-Ahead Logging (WAL)**, política de **checkpoints**, medidas de **anti-corrupción** y **backups/restore guiados**.
 
-### Ruta de la base de datos (Windows)
-- **Elegida:** C:\\ProgramData\\Tortilleria\\data\\app.sqlite  
-- **Alternativa:** %LocalAppData%\\Tortilleria\\data\\app.sqlite
-
-### PRAGMAs oficiales (producción; modo rendimiento entre paréntesis)
+### PRAGMAs oficiales (prod; modo rendimiento entre paréntesis)
 - `PRAGMA journal_mode = WAL;`
-- `PRAGMA synchronous = NORMAL;` *(**FULL** en operaciones críticas: “corte de caja”, migraciones y actualización offline).*
+- `PRAGMA synchronous = NORMAL;` (**FULL** en “corte de caja”, migraciones y actualización offline)
 - `PRAGMA foreign_keys = ON;`
 - `PRAGMA busy_timeout = 5000;`
-- `PRAGMA wal_autocheckpoint = 1000;` *(ajustable por métricas)*
+- `PRAGMA wal_autocheckpoint = 1000;` (ajustable por métricas)
 - `PRAGMA locking_mode = NORMAL;`
 - `PRAGMA temp_store = MEMORY;`
 - **Al crear DB**: `PRAGMA page_size = 4096;`
@@ -26,59 +22,40 @@ Usar **SQLite** local con **Write-Ahead Logging (WAL)**, política de checkpoint
 - Seguridad: `PRAGMA trusted_schema = OFF;`
 - Versionado: `PRAGMA user_version = <entero>`
 
+### Rutas Windows
+- Elegida: `C:\\ProgramData\\Tortilleria\\data\\app.sqlite`  
+- Alternativa (por usuario): `%LocalAppData%\\Tortilleria\\data\\app.sqlite`
+
 ## Alternativas consideradas
-1) PostgreSQL local — robusto, pero instalación/servicio pesados para offline.  
-2) SQL Server Express LocalDB — footprint mayor y complejidad.  
-3) Archivos JSON/CSV — sin transacciones reales, riesgo de corrupción.  
-4) SQLite sin WAL — menor concurrencia y mayor latencia de escritura.
+PostgreSQL local; SQL Server Express LocalDB; archivos JSON/CSV; SQLite sin WAL.
 
 ## Consecuencias
 **Pro:** setup mínimo, ACID, buena lectura concurrente con WAL, backups sencillos.  
-**Contra:** gestionar tamaño del WAL y política de checkpoints; ajustar `synchronous` por caso.
+**Contra:** gestionar tamaño del WAL/checkpoints; ajustar `synchronous` por caso.
 
 ## RNF soportados
 Rendimiento (≥100 ventas/hora), confiabilidad tras crash, integridad (transacciones + FK), operación offline, seguridad (cifrado de backups), mantenibilidad (PRAGMAs documentados y métricas).
 
 ## Estrategia WAL y checkpoints
 - Automático: `wal_autocheckpoint = 1000` páginas (ajustable).  
-- Manual (forzado):
-  - Al **salir** de la app.
-  - Tras **corte de caja** (con `synchronous=FULL`).
-  - Cuando **WAL > 256 MB** → `PRAGMA wal_checkpoint(TRUNCATE);` (fallback a `PASSIVE` si falla).
+- Manual (forzado): al salir, tras **corte de caja** (con `synchronous=FULL`) y cuando **WAL > 256 MB** → `PRAGMA wal_checkpoint(TRUNCATE);` (fallback a `PASSIVE`).
 
-## Plan anti-corrupción (cierres inesperados)
-- Transacciones en operaciones críticas.
-- `synchronous=NORMAL` por defecto; **FULL** en eventos críticos.
-- **Startup checks**: `PRAGMA quick_check` semanal o bajo demanda.
-- **Runbook**: backup con **Backup API** → restore → verificación → reintentos; registrar incidente.
+## Plan anti-corrupción
+Transacciones en operaciones críticas; `synchronous=NORMAL` por defecto y **FULL** en eventos críticos; `PRAGMA quick_check` semanal; recuperación con **Backup API** y registro del incidente.
 
 ## Backups & restore
-- Frecuencia: diario (reten 7), semanal (reten 4) + **USB** opcional.
-- Método: **SQLite Backup API** (consistente con WAL).
-- Verificación: `PRAGMA integrity_check` sobre el **backup**.
-- Cifrado: ZIP/AES o EFS; custodiar llaves.
-- Restore guiado: selector → verificación → reemplazo atómico → reabrir app.
+Diario (reten 7) y semanal (reten 4) + USB opcional; verificación con `PRAGMA integrity_check` sobre el **backup**; cifrado (ZIP/AES o EFS); restore atómico guiado.
 
 ## Observabilidad
-- Log inicial: valores reales de PRAGMAs y rutas.
-- Métricas: tamaño DB, tamaño WAL, tiempo de checkpoint, #`SQLITE_BUSY`, #recoveries.
-- Alertas locales: WAL > 256 MB, `quick_check` fallido, ≥3 `BUSY`/60s.
+Log inicial de PRAGMAs/rutas; métricas (DB/WAL/tiempo checkpoint/`SQLITE_BUSY`/recoveries); alertas: WAL >256 MB, `quick_check` fallido, ≥3 `BUSY`/60s.
 
 ## Métricas de aceptación
-- Resiliencia a crash: tras abortar 100 escrituras, la DB abre y pasa `quick_check`.
-- WAL controlado: no supera 256 MB bajo carga típica o se checkpoint-ea a tiempo.
-- Corte de caja seguro: con **FULL**, latencia aceptable e integridad ok.
-- Backup/restore: backup diario verificado y restore exitoso en ≤5 min.
+Resiliencia a crash (abre y pasa `quick_check`); WAL controlado (<256 MB o checkpoint a tiempo); corte de caja seguro con **FULL**; backup/restore en ≤ 5 min.
 
 ## Plan de adopción
-1) Congelar PRAGMAs y rutas.  
-2) Automatizar checkpoints (salida/corte/umbral WAL).  
-3) Programar `quick_check` semanal y pipeline de backups.  
-4) Añadir logs/alertas.  
-5) Ensayar recuperación (tabletop + prueba en QA).
+Congelar PRAGMAs y rutas → automatizar checkpoints → `quick_check` semanal y pipeline de backups → logs/alertas → ensayo de recuperación.
 
 ## Aprobaciones
 - Tech Lead: ______ (fecha)  
 - QA Lead: ________ (fecha)  
 - Cliente/PO: _____ (fecha)
-

--- a/tortilleria/docs/arch/c4-contenedores.md
+++ b/tortilleria/docs/arch/c4-contenedores.md
@@ -1,29 +1,37 @@
-# C4 — Contenedores
+# C4 — Diagrama de Contenedores · Sistema Tortillería
 
 ```mermaid
 flowchart LR
-  subgraph DesktopApp[App Desktop]
-    shell[Shell NativePHP]:::cmp
-    ui[UI Vue]:::cmp
-    core[Laravel Core]:::cmp
-    sqlite[(SQLite)]:::db
-    sync[Servicio Sync]:::svc
-    pdf[Servicio PDF]:::svc
-    backups[Backups]:::svc
-    logs[Logs]:::svc
-    updater[Updater]:::svc
+  subgraph S[Tortillería · App Desktop Offline]
+    shell[NativePHP · Shell Desktop]:::container
+    ui[Vue 3 + Tailwind · UI]:::container
+    core[Laravel Core<br/>(Inventario/Kardex, Ventas/POS, Cajas, Reparto, Reportes, Auditoría)]:::container
+    db[(SQLite local)]:::database
+    sync[Agente de Sync / Colas<br/>SQLite ⇄ PostgreSQL]:::container
+    pdf[Servicio PDF / Impresión]:::container
+    backup[Servicio Backups/Restore]:::container
+    logs[Logs + Auditoría]:::container
+    updater[Actualizador Offline + Rollback]:::container
   end
+
+  printer[[Impresora / PDF Viewer]]:::external
+  usb[[USB (cifrado)]]:::external
+  pg[(PostgreSQL SaaS)]:::external
 
   shell --> ui
   ui --> core
-  core --> sqlite
-  core --> sync
+  shell <--> core
+  core --> db
   core --> pdf
-  core --> backups
   core --> logs
-  updater --> core
+  core --> backup
+  sync --> db
 
-  classDef cmp fill:#eef6ff,stroke:#3b82f6,stroke-width:1px;
-  classDef svc fill:#f6f6f6,stroke:#999,stroke-width:1px;
-  classDef db fill:#fffbe6,stroke:#eab308,stroke-width:1px;
+  pdf --- printer
+  backup --- usb
+  sync --- pg
+
+  classDef container fill:#fff,stroke:#666,stroke-width:1px;
+  classDef database fill:#fffbe6,stroke:#eab308,stroke-width:1px;
+  classDef external fill:#eef6ff,stroke:#3b82f6,stroke-width:1px;
 ```

--- a/tortilleria/docs/arch/c4-contexto.md
+++ b/tortilleria/docs/arch/c4-contexto.md
@@ -1,29 +1,28 @@
-# C4 — Contexto
+# C4 — Diagrama de Contexto · Sistema Tortillería
 
 ```mermaid
 flowchart LR
-  subgraph Actores
-    dueno[Dueño]
-    supervisor[Supervisor]
-    admin[Admin]
-    despachador[Despachador]
-    repartidor[Repartidor]
+  A[Cliente]:::actor
+  B[Despachador / Repartidor]:::actor
+  C[Dueño / Supervisor / Admin]:::actor
+
+  subgraph S[Tortillería · App Desktop Offline]
   end
 
-  app[App Desktop]:::app
-  impresora[Impresora/PDF]:::ext
-  usb[(USB)]:::ext
-  saas[(Postgres SaaS)]:::ext
+  P[[Impresora / PDF]]:::external
+  U[[USB (Backups cifrados)]]:::external
+  N[(PostgreSQL SaaS · Sync opcional)]:::external
 
-  dueno --> app
-  supervisor --> app
-  admin --> app
-  despachador --> app
-  repartidor --> app
-  app --> impresora
-  app --> usb
-  app --> saas
+  A -->|Compra / Ticket| S
+  B -->|POS / Reparto| S
+  C -->|Admin / Reportes| S
 
-  classDef app fill:#eef6ff,stroke:#3b82f6,stroke-width:1px;
-  classDef ext fill:#f6f6f6,stroke:#999,stroke-width:1px;
+  S -->|Comprobantes| P
+  S -->|Backups| U
+  S ---|Sincroniza cuando hay Internet| N
+
+  classDef actor fill:#f6f6f6,stroke:#999,stroke-width:1px;
+  classDef external fill:#eef6ff,stroke:#3b82f6,stroke-width:1px;
 ```
+
+Leyenda: Actores, Sistema, Externos.

--- a/tortilleria/docs/backlog/moscow.md
+++ b/tortilleria/docs/backlog/moscow.md
@@ -1,21 +1,20 @@
-# Backlog — MoSCoW
+# Backlog MoSCoW (resumen)
 
 ## Must
-- Punto de venta offline
-  - **Criterios de aceptación:** registrar ventas sin conexión y persistir en SQLite.
-- Gestión de inventario
-  - **Criterios de aceptación:** actualizar existencias y kardex automáticamente.
-- Backups automáticos
-  - **Criterios de aceptación:** ejecutar backup diario y verificar integridad.
+- Desktop offline (instalador USB), Auth+RBAC, Inventario+Kardex, Masa→Totopos.
+- Ventas, Cajas (apertura/corte), Reparto + Reporte por tienda.
+- Validación/Sanitización, Auditoría.
+- Reportes (mes/producto/monto) con líneas, export PDF/CSV.
+- Backups y Restore, Actualización offline.
 
 ## Should
-- Sincronización con SaaS
-- Reportes PDF
+- Logs y visor de eventos, colas de sincronización, atajos POS, plantillas PDF.
 
 ## Could
-- Integración con impresoras de red
-- Soporte multi idioma
+- Etiquetas/QR, histórico comparativo anual, combos.
 
-## Won't
-- Aplicación móvil nativa
-- Integración con CRM externo
+## Won’t (ahora)
+- Sucursales, integraciones nube avanzadas, mapas en vivo pesados.
+
+**Criterios de aceptación (Must)**  
+- Venta valida stock; Kardex registra E/S/transformaciones; apertura/corte por rol con PDF; reportes con filtros y export; backups automáticos y restore verificable; actualización offline con rollback.

--- a/tortilleria/docs/roadmap/saas.md
+++ b/tortilleria/docs/roadmap/saas.md
@@ -1,9 +1,11 @@
-# Roadmap SaaS
+# Roadmap SaaS (multitenencia y sincronización)
 
-## Estrategia de multitenencia y sincronización
+## Fase 1 (Desktop offline)
+- SQLite + WAL; backups; empaquetado; RBAC; reportes.
 
-1. **Fase 1 — `tenant_id`:** todas las tablas incluyen `tenant_id`; sincronización básica con SaaS.
-2. **Fase 2 — Esquemas por tenant:** aislamiento lógico con `schema` dedicado; migraciones preparadas desde inicio.
-3. **Fase 3 — Base de datos por tenant:** despliegue independiente, backups y restauración por cliente.
+## Fase 2 (Sync & Multitenant)
+- Sync diferido SQLite⇄PostgreSQL; resolución de conflictos; colas idempotentes.
+- Multitenencia: `tenant_id` (v1) → esquemas (v2) → DB por tenant (v3) según escala y aislamiento.
 
-La aplicación local prepara la "fase 2" desde el diseño, permitiendo migrar a esquemas dedicados sin refactorización mayor.
+## Fase 3 (SaaS Operativo)
+- Panel de tenants; facturación; monitoreo; despliegues azules; backups multi-tenant; operación 24/7.

--- a/tortilleria/docs/seguridad/auditoria.md
+++ b/tortilleria/docs/seguridad/auditoria.md
@@ -1,6 +1,13 @@
-# Seguridad — Auditoría
+# Diseño de Auditoría
 
-- Eventos críticos: autenticación, cambios de inventario, cortes de caja, configuraciones y sincronizaciones.
-- Registro inmutable append-only con sello de tiempo y usuario.
-- Retención mínima de 12 meses y exportación a SaaS.
-- Visor de auditoría con filtros y búsqueda por usuario/fecha.
+## Eventos críticos
+- Login/logout, altas/bajas/ajustes de inventario, Masa→Totopos, ventas, cortes de caja, entregas, backups/restore, actualizaciones/rollback.
+
+## Modelo (inmutable)
+- Usuario/rol, timestamp, entidad/ID, tipo de evento, payload mínimo (antes/después cuando aplique), host/IP (si disponible). Registros **append-only**.
+
+## Retención
+- 12 meses (configurable por política).
+
+## Consulta/Export
+- Visor por rango/entidad/usuario; filtros por tipo; export CSV/PDF.

--- a/tortilleria/docs/seguridad/rbac-matriz.md
+++ b/tortilleria/docs/seguridad/rbac-matriz.md
@@ -1,12 +1,11 @@
-# Seguridad — Matriz RBAC
+# Matriz RBAC — Sistema Tortillería
 
-| Recurso \ Rol | Dueño | Supervisor | Admin | Despachador | Repartidor |
-| --- | --- | --- | --- | --- | --- |
-| Usuarios | C/R/U/D | C/R/U | R | - | - |
-| Inventario | C/R/U/D | C/R/U | R | R | R |
-| Ventas | C/R/U/D | C/R/U | R | C/R | C/R |
-| Repartos | C/R/U/D | C/R/U | R | - | C/R |
-| Almacén | C/R/U/D | C/R | R | - | - |
-| Reportes | R | R | R | R | R |
+| Recurso                | Dueño | Supervisor | Admin | Despachador | Repartidor |
+|------------------------|:-----:|:----------:|:-----:|:-----------:|:----------:|
+| Inventario / Kardex    | CRUD  |    CRUD    | CRUD  |      R      |     R      |
+| Venta / Cobro          | CRUD  |    CRUD    | CRUD  |     C/R     |     R      |
+| Cajas (apertura/corte) |  Sí   |     Sí     |  No   |     No      |     No     |
+| Reparto / Entregas     |   R   |     R      |  R    |    CRUD     |     C      |
+| Reportes               | Todos | Operativos |Operativos| Operativos | Personales |
 
-**Regla:** empleados (Despachador, Repartidor) no alteran almacén.
+**Regla crítica:** Empleados (Despachador/Repartidor) **no** pueden modificar el almacén.

--- a/tortilleria/docs/seguridad/validacion-sanitizacion.md
+++ b/tortilleria/docs/seguridad/validacion-sanitizacion.md
@@ -1,7 +1,16 @@
-# Seguridad — Validación y Sanitización
+# Validación y Sanitización
 
-- Todas las entradas se validan con reglas explícitas (tipos, rangos, formatos).
-- Sanitizar cadenas: `trim`, normalización UTF-8, escape de HTML.
-- Mensajes de error claros y localizados.
-- Al fallar la validación se responde con **422** y detalle del campo.
-- Registrar intentos inválidos y regresar respuestas consistentes.
+## Principios
+- Validar **todo input** antes de persistir.
+- Sanitizar strings (trim/escape) y normalizar números/fechas.
+- Mensajes claros y consistentes (por rol/flujo).
+
+## Reglas por módulo (ejemplos)
+- **Inventario:** cantidades > 0, costos ≥ 0, FK existentes.
+- **POS:** stock suficiente, descuentos válidos, totales ≈ sumas de líneas.
+- **Cajas:** apertura/cierre en orden; arqueo cuadrado (tolerancia definida).
+- **Reparto:** tienda válida, evidencia opcional offline.
+
+## Errores
+- Responder 422 con detalle campo→regla; no exponer stack.
+- Bitácora de intentos inválidos en auditoría (nivel info).


### PR DESCRIPTION
## Summary
- add ADR-002 for SQLite persistence and WAL
- document C4 context and container diagrams
- add security design docs, backlog, and roadmap references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab90864a9c8325b2d89c87ca38c46b