### PR TITLE
Add S0T11 threat model documentation and test

### DIFF
--- a/tests/Unit/S0T11ThreatModelDocTest.php
+++ b/tests/Unit/S0T11ThreatModelDocTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class S0T11ThreatModelDocTest extends TestCase
+{
+    private string $docPath = __DIR__ . '/../../tortilleria/docs/threat-model-s0t11.md';
+
+    public function test_threat_model_document_exists(): void
+    {
+        $this->assertFileExists($this->docPath);
+    }
+
+    public function test_threat_model_document_has_at_least_six_threats(): void
+    {
+        $contents = file_get_contents($this->docPath);
+        preg_match_all('/^### /m', $contents, $matches);
+        $this->assertGreaterThanOrEqual(6, count($matches[0]));
+    }
+}

--- a/tortilleria/docs/threat-model-s0t11.md
+++ b/tortilleria/docs/threat-model-s0t11.md
@@ -1,0 +1,48 @@
+# Threat Model S0T11
+
+## Activos clave
+- Inventario
+- Ventas
+- Caja
+- Usuarios
+
+## Amenazas (STRIDE simplificado)
+
+### Spoofing (abuso de roles)
+- **Amenaza:** Usuarios malintencionados se hacen pasar por administradores para modificar operaciones.
+- **Mitigación:** Autenticación multifactor y revisiones periódicas de privilegios.
+
+### Tampering (manipulación de archivos)
+- **Amenaza:** Alteración de archivos de configuración o registros de ventas.
+- **Mitigación:** Controles de integridad y uso de control de versiones con permisos restringidos.
+
+### Repudiation (ventas anuladas sin registro)
+- **Amenaza:** Empleados anulan ventas sin que quede evidencia.
+- **Mitigación:** Registro inmutable de eventos y auditorías frecuentes.
+
+### Information Disclosure
+- **Amenaza:** Exposición de información de clientes y precios.
+- **Mitigación:** Cifrado en reposo y en tránsito, políticas de acceso mínimo.
+
+### Denial of Service
+- **Amenaza:** Saturación del sistema de ventas y caja.
+- **Mitigación:** Monitoreo de tráfico y escalado automático de recursos.
+
+### Elevation of Privilege
+- **Amenaza:** Escalada de permisos para ejecutar acciones críticas.
+- **Mitigación:** Revisión de roles y pruebas de penetración regulares.
+
+## Tabla de priorización
+
+| Amenaza | Impacto | Probabilidad |
+|---------|---------|--------------|
+| Spoofing (abuso de roles) | Alto | Medio |
+| Tampering (manipulación de archivos) | Alto | Bajo |
+| Repudiation | Medio | Medio |
+| Information Disclosure | Alto | Bajo |
+| Denial of Service | Alto | Medio |
+| Elevation of Privilege | Crítico | Bajo |
+
+## Responsables
+- Equipo de Seguridad
+- Equipo de Desarrollo


### PR DESCRIPTION
## Summary
- Add threat model document covering key assets and STRIDE threats
- Create PHPUnit test ensuring threat model doc exists and lists six threats

## Testing
- `php artisan test` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68b084ddef2c8325aaa144ad3da15004