### PR TITLE
chore: ignore sqlite binaries, update docs with manual creation step

### DIFF
--- a/tortilleria/.gitignore
+++ b/tortilleria/.gitignore
@@ -22,3 +22,4 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+/database/*.sqlite

--- a/tortilleria/docs/full-setup-check.md
+++ b/tortilleria/docs/full-setup-check.md
@@ -1,0 +1,5 @@
+# Full Setup Check
+
+## Laravel Base
+
+⚠️ El archivo `database/database.sqlite` no está en el repo. Cada developer debe crearlo manualmente con `touch database/database.sqlite` antes de correr migraciones y tests.


### PR DESCRIPTION
## Summary
- ignore SQLite database binaries
- document manual creation of local SQLite database file

## Testing
- `php artisan migrate:fresh --seed`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b090043f6c8325bad4e5111125bdfd